### PR TITLE
Enable camera controls

### DIFF
--- a/OrbitalMechanics.cpp
+++ b/OrbitalMechanics.cpp
@@ -5,6 +5,7 @@
 #define DEBUG
 #ifdef DEBUG
 #include <iostream>
+#include <glm/gtx/string_cast.hpp> // glm::to_string
 #define LOG(ARGS) std::cout << ARGS << std::endl;
 #else
 #define LOG(ARGS)
@@ -52,8 +53,35 @@ void Rocket::update(float dthrust, float dtheta, float elapsed) {
 	pos = orbit->get_pos();
 	vel = orbit->get_vel();
 	orbit->predict();
-
 	transform->position = pos;
+
+	/// TODO: clean up the physics of this
+#define ZERO_SPACE_FRICTION true // we can change this if we want acceleration not to decay
+#if ZERO_SPACE_FRICTION
+	rotacc = glm::vec3(0.f, 0.f, theta_thrust);
+#else
+	if (theta_thrust != 0.f)
+	{
+		rotacc = glm::vec3(0.f, 0.f, theta_thrust);
+	}
+	rotacc *= 0.9; // slight decay in rotational acceleration
+#endif
+
+	rotvel += elapsed * rotacc;
+	rot += elapsed * rotvel;
+	{ // bound rotation angles within -pi, pi
+		auto bound_angles = [](float &angle){
+			if (angle > M_PI)
+				angle -= 2 * M_PI;
+			if (angle < -M_PI)
+				angle += 2 * M_PI;
+		};
+		bound_angles(rot.x);
+		bound_angles(rot.y);
+		bound_angles(rot.z);
+	}
+	
+	transform->rotation = glm::quat(rot);
 }
 
 // Create new orbit based on old one

--- a/OrbitalMechanics.cpp
+++ b/OrbitalMechanics.cpp
@@ -46,42 +46,47 @@ void Rocket::init(Orbit *orbit_, Scene::Transform *transform_) {
 }
 
 void Rocket::update(float dthrust, float dtheta, float elapsed) {
-	//TODO
 
-	assert(orbit != nullptr && transform != nullptr);
-	orbit->update(elapsed);
-	pos = orbit->get_pos();
-	vel = orbit->get_vel();
-	orbit->predict();
-	transform->position = pos;
-
+	{ // rocket controls & physics
 	/// TODO: clean up the physics of this
-#define ZERO_SPACE_FRICTION true // we can change this if we want acceleration not to decay
-#if ZERO_SPACE_FRICTION
-	rotacc = glm::vec3(0.f, 0.f, theta_thrust);
-#else
-	if (theta_thrust != 0.f)
-	{
+	#define ZERO_SPACE_FRICTION true // we can change this if we want acceleration not to decay
+	#if ZERO_SPACE_FRICTION
 		rotacc = glm::vec3(0.f, 0.f, theta_thrust);
-	}
-	rotacc *= 0.9; // slight decay in rotational acceleration
-#endif
+	#else
+		if (theta_thrust != 0.f)
+		{
+			rotacc = glm::vec3(0.f, 0.f, theta_thrust);
+		}
+		rotacc *= 0.9; // slight decay in rotational acceleration
+	#endif
 
-	rotvel += elapsed * rotacc;
-	rot += elapsed * rotvel;
-	{ // bound rotation angles within -pi, pi
-		auto bound_angles = [](float &angle){
-			if (angle > M_PI)
-				angle -= 2 * M_PI;
-			if (angle < -M_PI)
-				angle += 2 * M_PI;
-		};
-		bound_angles(rot.x);
-		bound_angles(rot.y);
-		bound_angles(rot.z);
+		rotvel += elapsed * rotacc;
+		rot += elapsed * rotvel;
+		{ // bound rotation angles within -pi, pi
+			auto bound_angles = [](float &angle){
+				if (angle > M_PI)
+					angle -= 2 * M_PI;
+				if (angle < -M_PI)
+					angle += 2 * M_PI;
+			};
+			bound_angles(rot.x);
+			bound_angles(rot.y);
+			bound_angles(rot.z);
+		}
+		theta = rot.z; // yaw (rotation alonx XY plane)
+		transform->rotation = glm::quat(rot);
 	}
-	
-	transform->rotation = glm::quat(rot);
+
+	{ // orbital mechanics
+		/// TODO: use thrust/theta to update/reconfigure orbit?
+		assert(orbit != nullptr && transform != nullptr);
+		orbit->update(elapsed);
+		pos = orbit->get_pos();
+		vel = orbit->get_vel();
+		last_orbit_vel = vel;
+		orbit->predict();
+		transform->position = pos;
+	}
 }
 
 // Create new orbit based on old one

--- a/OrbitalMechanics.hpp
+++ b/OrbitalMechanics.hpp
@@ -61,9 +61,15 @@ struct Rocket {
 	glm::vec3 vel;
 	glm::vec3 acc;
 
+	// rotational euler mechanics
+	glm::vec3 rot{0.f, 0.f, 0.f};
+	glm::vec3 rotvel{0.f, 0.f, 0.f};
+	glm::vec3 rotacc{0.f, 0.f, 0.f};
+
 	static float constexpr DryMass = 4.0f; // Megagram
 
 	bool stability_dampening = true; //controls SAS, dampens angular momentum
+	float theta_thrust = 0.0f; // acceleration for theta (yaw rotation)
 	float theta = 0.0f; //rotation along XY plane
 	float h = 0.0f; //angular momentum
 	float fuel = 8.0f; //measured by mass, Megagram

--- a/OrbitalMechanics.hpp
+++ b/OrbitalMechanics.hpp
@@ -58,7 +58,7 @@ struct Rocket {
 	Scene::Transform *transform;
 
 	glm::vec3 pos;
-	glm::vec3 vel;
+	glm::vec3 vel, last_orbit_vel;
 	glm::vec3 acc;
 
 	// rotational euler mechanics
@@ -71,6 +71,7 @@ struct Rocket {
 	bool stability_dampening = true; //controls SAS, dampens angular momentum
 	float theta_thrust = 0.0f; // acceleration for theta (yaw rotation)
 	float theta = 0.0f; //rotation along XY plane
+	float thrust = 0.0f; // forward thrust
 	float h = 0.0f; //angular momentum
 	float fuel = 8.0f; //measured by mass, Megagram
 };

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -270,54 +270,23 @@ void PlayMode::update_camera_view() {
 }
 
 void PlayMode::update(float elapsed) {
-
-	//slowly rotates through [0,1):
-	// wobble += elapsed / 10.0f;
-	// wobble -= std::floor(wobble);
-
-	// hip->rotation = hip_base_rotation * glm::angleAxis(
-	// 	glm::radians(5.0f * std::sin(wobble * 2.0f * float(M_PI))),
-	// 	glm::vec3(0.0f, 1.0f, 0.0f)
-	// );
-	// upper_leg->rotation = upper_leg_base_rotation * glm::angleAxis(
-	// 	glm::radians(7.0f * std::sin(wobble * 2.0f * 2.0f * float(M_PI))),
-	// 	glm::vec3(0.0f, 0.0f, 1.0f)
-	// );
-	// lower_leg->rotation = lower_leg_base_rotation * glm::angleAxis(
-	// 	glm::radians(10.0f * std::sin(wobble * 3.0f * 2.0f * float(M_PI))),
-	// 	glm::vec3(0.0f, 0.0f, 1.0f)
-	// );
-
-	//move sound to follow leg tip position:
-	// leg_tip_loop->set_position(get_leg_tip_position(), 1.0f / 60.0f);
-
-	//move camera:
-	// {
-
-	// 	//combine inputs into a move:
-	// 	constexpr float PlayerSpeed = 30.0f;
-	// 	glm::vec2 move = glm::vec2(0.0f);
-	// 	if (left.pressed && !right.pressed) move.x =-1.0f;
-	// 	if (!left.pressed && right.pressed) move.x = 1.0f;
-	// 	if (down.pressed && !up.pressed) move.y =-1.0f;
-	// 	if (!down.pressed && up.pressed) move.y = 1.0f;
-
-	// 	//make it so that moving diagonally doesn't go faster:
-	// 	if (move != glm::vec2(0.0f)) move = glm::normalize(move) * PlayerSpeed * elapsed;
-
-	// 	glm::mat4x3 frame = camera->transform->make_local_to_parent();
-	// 	glm::vec3 frame_right = frame[0];
-	// 	//glm::vec3 up = frame[1];
-	// 	glm::vec3 frame_forward = -frame[2];
-
-	// 	camera->transform->position += move.x * frame_right + move.y * frame_forward;
-	// }
-
-	if (tab.downs == 1) {
-		uint8_t dir = shift.pressed ? -1 : 1;
-		camera_view_idx = (camera_view_idx + dir * 1) % focus_points.size();
+	{ // update camera controls
+		if (tab.downs == 1) {
+			uint8_t dir = shift.pressed ? -1 : 1;
+			camera_view_idx = (camera_view_idx + dir * 1) % focus_points.size();
+		}
+		update_camera_view();
 	}
-	update_camera_view();
+
+	{ // update rocket controls
+		if (left.downs){
+			spaceship.theta_thrust = 1.f;
+		} else if (right.downs){
+			spaceship.theta_thrust = -1.f;
+		} else {
+			spaceship.theta_thrust = 0.f;
+		}
+	}
 
 	{ //update listener to camera position:
 		glm::mat4x3 frame = camera->transform->make_local_to_parent();

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -220,6 +220,9 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 			);
 			return true;
 		}
+	} else if(evt.type == SDL_MOUSEWHEEL) {
+		scroll_zoom += evt.wheel.y;
+		// evt.wheel.x for horizontal scrolling
 	}
 	//TODO: down the line, we might want to record mouse motion if we want to support things like click-and-drag
 	//(for orbital manuever planning tool)
@@ -229,18 +232,20 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 
 void PlayMode::update_camera_view() {
 	const glm::vec3 &focus_point = *(focus_points[camera_view_idx].first);
-	const float scale = focus_points[camera_view_idx].second;
+	const float radius = focus_points[camera_view_idx].second;
 
-	camera_arm_length = 10 * scale;
+	// camera arm length depends on radius
+	// have the scroll zooming affect the arm length by 1/cam_scale
+	camera_arm_length = radius * (cam_scale + (1.f / cam_scale) * scroll_zoom);
 
 	glm::mat4x3 frame = camera->transform->make_local_to_parent();
 	glm::vec3 right_vec = frame[0];
 	glm::vec3 up_vec = frame[1];
 	// glm::vec3 forward_vec = -frame[2];
 
-	const float mx = scale * -10.f;
-	const float my = scale * -10.f;
-	camera_offset += mx * mouse_motion_rel.x * right_vec + my * mouse_motion_rel.y * up_vec;
+	const float mx = radius * cam_scale;
+	const float my = radius * cam_scale;
+	camera_offset -= mx * mouse_motion_rel.x * right_vec + my * mouse_motion_rel.y * up_vec;
 
 	// reset the delta's so the camera stops when mouse up
 	mouse_motion_rel = glm::vec2(0, 0);

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -193,6 +193,10 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 			shift.downs += 1;
 			shift.pressed = true;
 			return true;
+		} else if (evt.key.keysym.sym == SDLK_LCTRL) {
+			control.downs += 1;
+			control.pressed = true;
+			return true;
 		}
 	} else if (evt.type == SDL_KEYUP) {
 		if (evt.key.keysym.sym == SDLK_a) {
@@ -212,6 +216,9 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 			return true;
 		} else if (evt.key.keysym.sym == SDLK_LSHIFT) {
 			shift.pressed = false;
+			return true;
+		} else if (evt.key.keysym.sym == SDLK_LCTRL) {
+			control.pressed = false;
 			return true;
 		}
 	} else if (evt.type == SDL_MOUSEBUTTONDOWN) {
@@ -279,12 +286,20 @@ void PlayMode::update(float elapsed) {
 	}
 
 	{ // update rocket controls
-		if (left.downs){
+		if (left.downs) {
 			spaceship.theta_thrust = 1.f;
-		} else if (right.downs){
+		} else if (right.downs) {
 			spaceship.theta_thrust = -1.f;
 		} else {
 			spaceship.theta_thrust = 0.f;
+		}
+
+		if (shift.pressed) {
+			spaceship.thrust = 1.f;
+		} else if (control.pressed) {
+			spaceship.thrust = -1.f;
+		} else {
+			spaceship.thrust = 0.f;
 		}
 	}
 
@@ -308,6 +323,7 @@ void PlayMode::update(float elapsed) {
 	down.downs = 0;
 	tab.downs = 0;
 	shift.downs = 0;
+	control.downs = 0;
 }
 
 void PlayMode::draw(glm::uvec2 const &drawable_size) {

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -189,6 +189,10 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 			tab.downs += 1;
 			tab.pressed = true;
 			return true;
+		} else if (evt.key.keysym.sym == SDLK_LSHIFT) {
+			shift.downs += 1;
+			shift.pressed = true;
+			return true;
 		}
 	} else if (evt.type == SDL_KEYUP) {
 		if (evt.key.keysym.sym == SDLK_a) {
@@ -205,6 +209,9 @@ bool PlayMode::handle_event(SDL_Event const &evt, glm::uvec2 const &window_size)
 			return true;
 		} else if (evt.key.keysym.sym == SDLK_TAB) {
 			tab.pressed = false;
+			return true;
+		} else if (evt.key.keysym.sym == SDLK_LSHIFT) {
+			shift.pressed = false;
 			return true;
 		}
 	} else if (evt.type == SDL_MOUSEBUTTONDOWN) {
@@ -307,7 +314,8 @@ void PlayMode::update(float elapsed) {
 	// }
 
 	if (tab.downs == 1) {
-		camera_view_idx = (camera_view_idx + 1) % focus_points.size();
+		uint8_t dir = shift.pressed ? -1 : 1;
+		camera_view_idx = (camera_view_idx + dir * 1) % focus_points.size();
 	}
 	update_camera_view();
 
@@ -330,6 +338,7 @@ void PlayMode::update(float elapsed) {
 	up.downs = 0;
 	down.downs = 0;
 	tab.downs = 0;
+	shift.downs = 0;
 }
 
 void PlayMode::draw(glm::uvec2 const &drawable_size) {

--- a/PlayMode.hpp
+++ b/PlayMode.hpp
@@ -23,7 +23,7 @@ struct PlayMode : Mode {
 	struct Button {
 		uint8_t downs = 0;
 		uint8_t pressed = 0;
-	} left, right, down, up;
+	} left, right, down, up, tab;
 
 	//local copy of the game scene (so code can change it during gameplay):
 	Scene scene;
@@ -44,5 +44,9 @@ struct PlayMode : Mode {
 
 	//camera:
 	Scene::Camera *camera = nullptr;
+	size_t camera_view_idx = 0;
+	// track locations and radii
+	std::vector<std::pair<glm::vec3 *, float>> focus_points = {}; 
+	void update_camera_view();
 
 };

--- a/PlayMode.hpp
+++ b/PlayMode.hpp
@@ -44,9 +44,11 @@ struct PlayMode : Mode {
 
 	//camera:
 	Scene::Camera *camera = nullptr;
+	const float cam_scale = 10.f; // use to scale camera motion
 	glm::vec3 camera_offset{0.f, 10.f, 10.f};
 	size_t camera_view_idx = 0;
 	float camera_arm_length = 1.f;
+	float scroll_zoom = 0.f;
 	glm::vec2 mouse_motion_rel{0.f, 0.f};
 	// track locations and radii
 	std::vector<std::pair<glm::vec3 *, float>> focus_points = {}; 

--- a/PlayMode.hpp
+++ b/PlayMode.hpp
@@ -23,7 +23,7 @@ struct PlayMode : Mode {
 	struct Button {
 		uint8_t downs = 0;
 		uint8_t pressed = 0;
-	} left, right, down, up, tab;
+	} left, right, down, up, tab, shift;
 
 	//local copy of the game scene (so code can change it during gameplay):
 	Scene scene;

--- a/PlayMode.hpp
+++ b/PlayMode.hpp
@@ -44,7 +44,10 @@ struct PlayMode : Mode {
 
 	//camera:
 	Scene::Camera *camera = nullptr;
+	glm::vec3 camera_offset{0.f, 10.f, 10.f};
 	size_t camera_view_idx = 0;
+	float camera_arm_length = 1.f;
+	glm::vec2 mouse_motion_rel{0.f, 0.f};
 	// track locations and radii
 	std::vector<std::pair<glm::vec3 *, float>> focus_points = {}; 
 	void update_camera_view();

--- a/PlayMode.hpp
+++ b/PlayMode.hpp
@@ -23,7 +23,7 @@ struct PlayMode : Mode {
 	struct Button {
 		uint8_t downs = 0;
 		uint8_t pressed = 0;
-	} left, right, down, up, tab, shift;
+	} left, right, down, up, tab, shift, control;
 
 	//local copy of the game scene (so code can change it during gameplay):
 	Scene scene;


### PR DESCRIPTION
First half of #3 (camera controls)
- Enable pressing `tab` (and `shift+tab` to go backwards) to switch between bodies to focus on.
- Rotate camera around bodies with mouse controls (drag)
- Zoom camera distance with mouse scroll
