### PR TITLE
Improved text rendering performance

### DIFF
--- a/MenuMode.cpp
+++ b/MenuMode.cpp
@@ -172,7 +172,7 @@ void MenuMode::ButtonSprite::draw(glm::vec2 const &drawable_size) const
 	if (text != nullptr && text->text_content.size() > 0)
 	{
 		glm::vec2 center_loc = top_left_loc + 0.5f * glm::vec2{_size.x, -1.2f * _size.y} * drawable_size;
-		text->draw(1.f, drawable_size, _size.x * 200.f, center_loc, 1.f, glm::u8vec4{0xff});
+		text->draw_immediate(1.f, drawable_size, _size.x * 200.f, center_loc, 1.f, glm::u8vec4{0xff});
 	}
 	HUD::drawElement(_size * drawable_size, top_left_loc, sprite, _color);
 }
@@ -281,5 +281,6 @@ void MenuMode::draw(glm::uvec2 const &drawable_size)
 		skybox.draw(camera);
 	}
 
+	Text::draw_all(drawable_size); // draws all characters in one fell swoop
 	GL_ERRORS();
 }

--- a/MenuMode.cpp
+++ b/MenuMode.cpp
@@ -261,8 +261,8 @@ void MenuMode::draw(glm::uvec2 const &drawable_size)
 	{ // start text
 		float x = drawable_size.x * 0.5f;
 		float y = drawable_size.y * 0.9f; // top is 1.f bottom is 0.f
-		float fontsize = drawable_size.x * 0.04f;
-		start_menu_text.draw(1.f, drawable_size, fontsize, glm::vec2(x, y), 1.4f, glm::u8vec4{0xff});
+		float fontsize = drawable_size.x * 0.05f;
+		start_menu_text.draw(1.f, drawable_size, fontsize, glm::vec2(x, y), 1.f, glm::u8vec4{0xff});
 	}
 
 	{ // other text

--- a/MenuMode.cpp
+++ b/MenuMode.cpp
@@ -172,7 +172,7 @@ void MenuMode::ButtonSprite::draw(glm::vec2 const &drawable_size) const
 	if (text != nullptr && text->text_content.size() > 0)
 	{
 		glm::vec2 center_loc = top_left_loc + 0.5f * glm::vec2{_size.x, -1.2f * _size.y} * drawable_size;
-		text->draw(1.f, drawable_size, _size.x * 200.f, center_loc, 1.f, glm::u8vec4{0xff});
+		text->draw(1.f, drawable_size, drawable_size.x * 0.02f, center_loc, 1.f, glm::u8vec4{0xff});
 	}
 	HUD::drawElement(_size * drawable_size, top_left_loc, sprite, _color);
 }

--- a/MenuMode.cpp
+++ b/MenuMode.cpp
@@ -172,7 +172,7 @@ void MenuMode::ButtonSprite::draw(glm::vec2 const &drawable_size) const
 	if (text != nullptr && text->text_content.size() > 0)
 	{
 		glm::vec2 center_loc = top_left_loc + 0.5f * glm::vec2{_size.x, -1.2f * _size.y} * drawable_size;
-		text->draw_immediate(1.f, drawable_size, _size.x * 200.f, center_loc, 1.f, glm::u8vec4{0xff});
+		text->draw(1.f, drawable_size, _size.x * 200.f, center_loc, 1.f, glm::u8vec4{0xff});
 	}
 	HUD::drawElement(_size * drawable_size, top_left_loc, sprite, _color);
 }
@@ -281,6 +281,5 @@ void MenuMode::draw(glm::uvec2 const &drawable_size)
 		skybox.draw(camera);
 	}
 
-	Text::draw_all(drawable_size); // draws all characters in one fell swoop
 	GL_ERRORS();
 }

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -708,7 +708,7 @@ void PlayMode::update(float elapsed) {
             }
 		}
 	}
-
+	LOG(1.f / elapsed);
 
 	if (playing) { // update rocket controls
 		{ // reset dilation on controls

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -708,7 +708,6 @@ void PlayMode::update(float elapsed) {
             }
 		}
 	}
-	LOG(1.f / elapsed);
 
 	if (playing) { // update rocket controls
 		{ // reset dilation on controls
@@ -1205,6 +1204,5 @@ void PlayMode::draw(glm::uvec2 const &drawable_size) {
 	/* HUD::drawElement(glm::vec2(80, (250 * thrust_amnt)), glm::vec2(140, 32 + (250 * thrust_amnt)), bar, color); */
 	/* HUD::drawElement(glm::vec2(120, 30), glm::vec2(120, 60 + (250 * thrust_amnt)), handle); */
 
-	Text::draw_all(drawable_size); // draws all characters in one fell swoop
 	GL_ERRORS();
 }

--- a/PlayMode.cpp
+++ b/PlayMode.cpp
@@ -1205,6 +1205,6 @@ void PlayMode::draw(glm::uvec2 const &drawable_size) {
 	/* HUD::drawElement(glm::vec2(80, (250 * thrust_amnt)), glm::vec2(140, 32 + (250 * thrust_amnt)), bar, color); */
 	/* HUD::drawElement(glm::vec2(120, 30), glm::vec2(120, 60 + (250 * thrust_amnt)), handle); */
 
-
+	Text::draw_all(drawable_size); // draws all characters in one fell swoop
 	GL_ERRORS();
 }

--- a/Text.hpp
+++ b/Text.hpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <array>
+#include <vector>
 
 // freetype
 #include <ft2build.h>
@@ -29,35 +31,40 @@ struct Character {
     glm::ivec2 Bearing; // Offset from baseline to left/top of glyph (glyph left,top)
     unsigned int Advance; // Offset to advance to next glyph
     GLvoid *data = nullptr;
+    float tx = 0.f; // index into the larger atlas texture if available
 
     // construct a character from a char request and typeface (glyph) collection
-    static Character Load(hb_codepoint_t request, FT_Face typeface)
+    static Character Load(hb_codepoint_t request, FT_Face typeface, bool bLoadTexture = true)
     {
         // taken almost verbatim from https://learnopengl.com/In-Practice/Text-Rendering
         if (FT_Load_Glyph(typeface, request, FT_LOAD_RENDER))
             throw std::runtime_error("Failed to load glyph: " + std::to_string(request));
-        GLuint tex;
-        glGenTextures(1, &tex);
-        glBindTexture(GL_TEXTURE_2D, tex);
-        glTexImage2D(
-            GL_TEXTURE_2D,
-            0,
-            GL_RED,
-            typeface->glyph->bitmap.width,
-            typeface->glyph->bitmap.rows,
-            0,
-            GL_RED,
-            GL_UNSIGNED_BYTE,
-            typeface->glyph->bitmap.buffer);
-        // set tex options
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); // not using mipmap
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // not using mipmap
+        GLuint tex = 0;
+        if (bLoadTexture) {
+            glGenTextures(1, &tex);
+            glBindTexture(GL_TEXTURE_2D, tex);
+            glTexImage2D(
+                GL_TEXTURE_2D,
+                0,
+                GL_RED,
+                typeface->glyph->bitmap.width,
+                typeface->glyph->bitmap.rows,
+                0,
+                GL_RED,
+                GL_UNSIGNED_BYTE,
+                typeface->glyph->bitmap.buffer);
+            // set tex options
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); // not using mipmap
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // not using mipmap
+
+        }
         // also store the bitmap buffer
         size_t size = typeface->glyph->bitmap.width * typeface->glyph->bitmap.rows * sizeof(char);
         GLvoid *data = malloc(size);
         memcpy(data, typeface->glyph->bitmap.buffer, size);
+        
         // now store character for later use
         return {
             tex,
@@ -86,11 +93,15 @@ struct Text {
     hb_font_t* hb_typeface = nullptr;
 
     // for drawing
-    inline static GLuint draw_text_program = 0;
-    inline static GLuint VAO = 0;
-    inline static GLuint VBO = 0;
-
-    inline static GLuint VBO_deferred = 0;
+    GLuint draw_text_program = 0;
+    GLuint VAO = 0;
+    GLuint VBO = 0;
+    
+    // shader params
+    GLint shader_tex;
+    GLint shader_coord;
+    GLint shader_proj;
+    GLint shader_color;
 
     // text anchor
     enum AnchorType : uint8_t {
@@ -104,25 +115,75 @@ struct Text {
     // for actual text content
     std::string text_content;
 
-    // using hb_codepoint_t as the codepoint type from hb_buffer_get_glyph_positions
-    std::map<hb_codepoint_t, Character> chars;
-
-
-    struct RenderCharacter {
-        RenderCharacter(const Character &c, glm::vec3 const &col, const float x, const float y, const float _w, const float _h) :
-           ch(c), color(col), xpos(x), ypos(y), w(_w), h(_h) {};
-        const Character ch;
-        const glm::vec3 color;
-        const float xpos, ypos;
-        const float w, h;
-        float tx = 0.f; // index into the larger atlas texture if available
-    };
-    inline static std::vector<RenderCharacter> render_chars;
-
     struct Atlas {
+        // attempting to "glom" all relevant textures to a single texture atlas
+        // https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Text_Rendering_02
         
-    };
+        GLuint tex;
+        unsigned int w, h;
+        std::array<Character, 128> chars;
 
+        Atlas(FT_Face face, int scale, glm::vec3 const &col) {
+            // create a single large atlas texture for all the ASCII characters of size scale & color col
+
+            FT_Set_Pixel_Sizes(face, 0, scale);
+		    FT_GlyphSlot g = face->glyph;
+            
+            // find the size of the atlas texture (1 x n texture)
+            w = 0; // width of all glyphs together
+            h = 0; // height of single tallest glyph
+            for (int i = 32; i < 128; i++) { // all ascii character
+			    if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
+                    throw std::runtime_error("Failed to load glyph: " + std::to_string(i));
+                    continue;
+                }
+
+                w += g->bitmap.width + 1;
+                h = std::max(h, g->bitmap.rows);
+            }
+
+            // create empty texture for atlas
+            glActiveTexture(GL_TEXTURE0);
+            glGenTextures(1, &tex);
+            glBindTexture(GL_TEXTURE_2D, tex);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, w, h, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
+            GL_ERRORS();
+
+            glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // 1 byte alignment
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); // clamping to avoid artifacts
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); // clamping to avoid artifacts
+            GL_ERRORS();
+
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); // linear filtering usually best for text
+            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // linear filtering usually best for text
+            GL_ERRORS();
+
+            // fill in the texture with all the glyphs
+            size_t x = 0;
+            for (int i = 32; i < 128; i++) {
+                if (FT_Load_Char(face, i, FT_LOAD_RENDER)) {
+                    fprintf(stderr, "Loading character %c failed!\n", i);
+                    continue;
+                }
+                Character ch{0, glm::ivec2{g->bitmap.width, g->bitmap.rows}, glm::ivec2{g->bitmap_left, g->bitmap_top}, (unsigned int)(g->advance.x), g->bitmap.buffer};
+                glTexSubImage2D(GL_TEXTURE_2D, 0, x, 0, ch.Size.x, ch.Size.y, GL_RED, GL_UNSIGNED_BYTE, ch.data);
+                ch.tx = static_cast<float>(x) / this->w;
+                chars[i] = ch;
+
+                /// TODO: check if this should be +1 or not?
+                x += ch.Size.x + 1; 
+            }
+            GL_ERRORS();
+            std::cout << "Generated Atlas with dims: (" << w << " x " << h << ")" << std::endl;
+        }
+
+        ~Atlas() {
+            if (tex != 0) {
+                glDeleteTextures(1, &tex);
+            }
+            GL_ERRORS();
+        }
+    };
 
     void init(AnchorType _anchor) {
         init(_anchor, false);
@@ -142,7 +203,7 @@ struct Text {
         }
 
         // create shaders for rendering
-        if (Text::draw_text_program == 0) {
+        if (draw_text_program == 0) {
             // https://learnopengl.com/code_viewer_gh.php?code=src/7.in_practice/2.text_rendering/text.vs
             const auto vertex_shader = "#version 330 core\n"
                                        "in vec4 coord;\n"
@@ -167,7 +228,7 @@ struct Text {
                                          "   color = vec4(textColor, 1.0) * sampled;\n"
                                          "   bright = vec4(vec3(0.0), 1.0);\n"
                                          "}\n";
-            Text::draw_text_program = gl_compile_program(vertex_shader, fragment_shader);
+            draw_text_program = gl_compile_program(vertex_shader, fragment_shader);
         }
 
         // set initial harfbuzz buffer params/data
@@ -177,16 +238,23 @@ struct Text {
             set_text("Initial text"); /// TODO: remove
         }
 
+
         // initialize openGL for rendering
-        if (Text::VAO == 0 || Text::VBO == 0) {
+        { // get shader params
+            shader_tex = glGetUniformLocation(draw_text_program, "tex");          // the atlas texture
+            shader_coord = glGetAttribLocation(draw_text_program, "coord");       // the texture coordinate
+            shader_proj = glGetUniformLocation(draw_text_program, "projection");  // the projection to screen
+            shader_color = glGetUniformLocation(draw_text_program, "textColor");  // the text color (RGB)
+        }
+
+        if (VAO == 0 || VBO == 0) {
             glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // disable byte-alignment restriction
             glEnable(GL_BLEND);
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            glGenVertexArrays(1, &Text::VAO);
-            glGenBuffers(1, &Text::VBO);
-            glBindVertexArray(Text::VAO);
-            glBindBuffer(GL_ARRAY_BUFFER, Text::VBO);
-            glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 6 * 4, nullptr, GL_DYNAMIC_DRAW);
+            glGenVertexArrays(1, &VAO);
+            glGenBuffers(1, &VBO);
+            glBindVertexArray(VAO);
+            glBindBuffer(GL_ARRAY_BUFFER, VBO);
             glEnableVertexAttribArray(0);
             glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);
             glBindBuffer(GL_ARRAY_BUFFER, 0);
@@ -238,277 +306,134 @@ struct Text {
             FT_Set_Char_Size(typeface, 0, static_cast< unsigned int>(font_size * font_scale), 0, 0); // 64 units per pixel
             if (FT_Load_Char(typeface, 'X', FT_LOAD_RENDER))
                 throw std::runtime_error("Failed to load char \"X\" from typeface!");
-            // reset these characters to regenerate them with the new font size
-            chars.clear();
         }
     }
 
-    hb_glyph_info_t* prepare_draw(float dt, const glm::vec2& drawable_size, float scale, const glm::vec2& pos, float ss_scale, glm::vec3 const &color, unsigned int &num_chars, float &amnt, float &char_x, float &char_y, float &anchor_x_start) {
-        float new_font_scale = scale; // scale font size off window height
-        set_font_size(font_size, new_font_scale);
-
-        num_chars = 0;
-        hb_glyph_info_t* glyph_info = hb_buffer_get_glyph_infos(hb_buffer, &num_chars);
-        if (glyph_info == nullptr) {
-            throw std::runtime_error("Unable to get glyph info from buffer!");
+    float calculate_start_anchor(Atlas *atlas, size_t &num_newlines, float left_pos, float ss_scale) {
+        if (atlas == nullptr) {
+            throw std::runtime_error("Atlas is null! cannot calculate start anchor!");
         }
 
         // calculate the final width of the text glyphs
         std::vector<float> line_widths;
         line_widths.push_back(0.f);
-        for (unsigned int i = 0; i < num_chars; i++) {
-            hb_codepoint_t char_req = glyph_info[i].codepoint;
-            if (chars.find(char_req) == chars.end()) { // not already loaded
-                Character ch = Character::Load(char_req, typeface);
-                chars.insert(std::pair<hb_codepoint_t, Character>(char_req, ch));
-            }
-
-            const Character& ch = chars[char_req];
+        for (char c : text_content) {
+            const Character& ch = atlas->chars[c];
 
             // now advance cursors for next glyph (note that advance is number of 1/64 pixels)
-            if (char_req == hb_codepoint_t{'\0'}) {
+            if (c == '\n') {
                 line_widths.push_back(0.f);
             }
             else {
-                line_widths[line_widths.size() - 1] += (ch.Advance >> 6) * ss_scale; // bitshift by 6 to get value in pixels (2^6 = 64)
+                line_widths.back() += (ch.Advance >> 6) * ss_scale; // bitshift by 6 to get value in pixels (2^6 = 64)
             }
         }
         float final_width = 0.f;
         for (float line_width : line_widths) {
             final_width = std::max(line_width, final_width);
         }
+        num_newlines = line_widths.size();
 
-        anchor_x_start = pos.x; // default (left)
+        float anchor_x_start = left_pos; // default (left)
         if (anchor == Text::AnchorType::CENTER) {
             anchor_x_start -= final_width / 2.f; // to be horizontally centered
         }
         else if (anchor == Text::AnchorType::RIGHT) {
             anchor_x_start -= final_width; // all the way to the right
         }
-
-        char_x = anchor_x_start;
-        char_y = pos.y;
-
-        // handle animation (only draw fraction of total depending on time)
-        time += dt;
-        amnt = std::min(time / (anim_time * line_widths.size()), 1.f);
-
-        return glyph_info;
+        return anchor_x_start;
     }
 
     void draw(float dt, const glm::vec2& drawable_size, float scale, const glm::vec2& pos, float ss_scale, glm::vec3 const &color) {
-        // draw a text element at once the draw_all() call is made, deferred can improve performance
+        ss_scale = 1.0f;
+        // draw a text element using an atlas texture to draw it all at once
 
-        unsigned int num_chars;
-        float amnt, char_x, char_y, anchor_x_start;
-        hb_glyph_info_t *glyph_info = prepare_draw(dt, drawable_size, scale, pos, ss_scale, color, num_chars, amnt, char_x, char_y, anchor_x_start);
+        /// TODO: support rebuilding the atlas on window resize/param change
+        Atlas *atlas = nullptr;
+        if (atlas == nullptr) {
+            /// TODO: make atlas "content-aware" so to only allocate memory & load necessary glyphs
+            atlas = new Atlas(typeface, scale, color);
+        }
+        
+        size_t num_newlines;
+        float anchor_x_start = calculate_start_anchor(atlas, num_newlines, pos.x, ss_scale);
+        float char_x = anchor_x_start;
+        float char_y = pos.y;
 
-        // this loop was taken almost verbatim from https://learnopengl.com/In-Practice/Text-Rendering
-        for (unsigned int i = 0; i < static_cast< unsigned int >(amnt * num_chars); i++) {
-            hb_codepoint_t char_req = glyph_info[i].codepoint;
-            if (chars.find(char_req) == chars.end()) { // not already loaded
-                Character ch = Character::Load(char_req, typeface);
-                chars.insert(std::pair<hb_codepoint_t, Character>(char_req, ch));
-            }
+        // handle animation (only draw fraction of total depending on time)
+        time += dt;
+        float amnt = std::min(time / (anim_time * num_newlines), 1.f); // 1.f => 100% is drawn
 
-            const Character& ch = chars[char_req];
-            if (char_req != hb_codepoint_t{'\0'}){
+        std::vector<float> render_data; // should be 6 * 4 * render_chars.size()
+        for (size_t i = 0; i < static_cast<size_t>(amnt * text_content.size()); i++) {
+            char char_req = text_content[i];
+            // std::cout << char_req << std::endl;
+            const Character& ch = atlas->chars[char_req];
+            if (char_req != '\n') {
                 float xpos = char_x + ch.Bearing.x * ss_scale;
                 float ypos = -char_y - (ch.Size.y - ch.Bearing.y) * ss_scale;
                 float w = ch.Size.x * ss_scale;
                 float h = ch.Size.y * ss_scale;
+                // if (!w || !h) // skip glyphs with no size
+                //     continue;
 
-                render_chars.emplace_back(ch, color, xpos, ypos, w, h);
-                // now advance cursors for next glyph (note that advance is number of 1/64 pixels)
-                char_x += (ch.Advance >> 6) * ss_scale; // bitshift by 6 to get value in pixels (2^6 = 64)
-            }
-            // / TODO: logic for newline? (reset x, increase y?)
-            else {
-                char_x = anchor_x_start; // reset x
-                char_y -= ch.Size.y; // increment Y
-            }
-        }
-    }
-
-
-    void draw_immediate(float dt, const glm::vec2& drawable_size, float scale, const glm::vec2& pos, float ss_scale, glm::vec3 const &color)
-    {
-        return;
-        // draw a text element immediately! (this directly talks to the GPU)
-
-        // drawable_size - window size
-        // scale - how wide the displayed string gets to be
-        // pos - position in screenspace where the text gets rendered
-        // ss_scale - screenspace scale (lower quality but cheap)
-        // color - rgb(1) colour
-
-        unsigned int num_chars;
-        float amnt, char_x, char_y, anchor_x_start;
-        hb_glyph_info_t *glyph_info = prepare_draw(dt, drawable_size, scale, pos, ss_scale, color, num_chars, amnt, char_x, char_y, anchor_x_start);
-
-        glUseProgram(Text::draw_text_program);
-
-        auto projection = glm::ortho(0.0f, drawable_size.x, 0.0f, drawable_size.y);
-        glUniformMatrix4fv(glGetUniformLocation(Text::draw_text_program, "projection"), 1, GL_FALSE, &projection[0][0]);
-        glUniform3f(glGetUniformLocation(Text::draw_text_program, "textColor"), color.x, color.y, color.z);
-        glActiveTexture(GL_TEXTURE0);
-        glBindVertexArray(Text::VAO);
-
-        // this loop was taken almost verbatim from https://learnopengl.com/In-Practice/Text-Rendering
-        for (unsigned int i = 0; i < static_cast< unsigned int >(amnt * num_chars); i++) {
-            hb_codepoint_t char_req = glyph_info[i].codepoint;
-            if (chars.find(char_req) == chars.end()) { // not already loaded
-                Character ch = Character::Load(char_req, typeface);
-                chars.insert(std::pair<hb_codepoint_t, Character>(char_req, ch));
-            }
-
-            const Character& ch = chars[char_req];
-            if (char_req != hb_codepoint_t{'\0'}) {
-                float xpos = char_x + ch.Bearing.x * ss_scale;
-                float ypos = char_y - (ch.Size.y - ch.Bearing.y) * ss_scale;
-                float w = ch.Size.x * ss_scale;
-                float h = ch.Size.y * ss_scale;
-
-                // update VBO for each character
-                float vertices[6][4] = {
-                    { xpos, ypos + h, 0.0f, 0.0f },
-                    { xpos, ypos, 0.0f, 1.0f },
-                    { xpos + w, ypos, 1.0f, 1.0f },
-
-                    { xpos, ypos + h, 0.0f, 0.0f },
-                    { xpos + w, ypos, 1.0f, 1.0f },
-                    { xpos + w, ypos + h, 1.0f, 0.0f }
-                };
-
-                glBindTexture(GL_TEXTURE_2D, ch.TextureID);
-                glBindBuffer(GL_ARRAY_BUFFER, Text::VBO);
-                glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(vertices), vertices);
-                glBindBuffer(GL_ARRAY_BUFFER, 0);
-                glDrawArrays(GL_TRIANGLES, 0, 6);
+                // each 4 tuple is a {x, y, s, t} to index into the vertex/texture coordinates/attribute
+                render_data.insert(render_data.end(), {
+                    xpos,     -ypos - h, ch.tx,                h / atlas->h,
+                    xpos,     -ypos,     ch.tx,                0.0f,
+                    xpos + w, -ypos,     ch.tx + w / atlas->w, 0.0f,
+                    xpos,     -ypos - h, ch.tx,                h / atlas->h,
+                    xpos + w, -ypos,     ch.tx + w / atlas->w, 0.0f,
+                    xpos + w, -ypos - h, ch.tx + w / atlas->w, h / atlas->h
+                });
 
                 // now advance cursors for next glyph (note that advance is number of 1/64 pixels)
                 char_x += (ch.Advance >> 6) * ss_scale; // bitshift by 6 to get value in pixels (2^6 = 64)
             }
-            // / TODO: logic for newline? (reset x, increase y?)
             else {
                 char_x = anchor_x_start; // reset x
-                char_y -= ch.Size.y; // increment Y
+                char_y -= atlas->h; // increment Y
             }
         }
 
-        // reset openGL stuff
-        glBindVertexArray(0);
-        glBindTexture(GL_TEXTURE_2D, 0);
-        glUseProgram(0);
+        // do opengl drawing!
+        glUseProgram(draw_text_program);
 
-        GL_ERRORS();
-    }
-
-    static void draw_all(const glm::vec2 &drawable_size) {
-        // attempting to "glom" all relevant rextures (sizes, shapes, colors) to a single texture atlas
-        // https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Text_Rendering_02
-        glUseProgram(Text::draw_text_program);
-
-        // find the size of the atlas texture
-        int atlas_width = 0; // width of all glyphs together
-        int atlas_height = 0; // height of single tallest glyph
-        for (const auto &rc : render_chars) {
-            atlas_width += rc.ch.Size.x;
-            atlas_height = std::max(atlas_height, rc.ch.Size.y);
-        }
-        // std::cout << "generated atlas with dims: " << atlas_width << " x " << atlas_height << std::endl;
-
-        auto tex = glGetUniformLocation(Text::draw_text_program, "tex");
-        auto attribute_coord = glGetAttribLocation(Text::draw_text_program, "coord");
-
-        // create empty texture for atlas
-        GLuint atlas_tex;
-        glActiveTexture(GL_TEXTURE0);
-        glGenTextures(1, &atlas_tex);
-        glBindTexture(GL_TEXTURE_2D, atlas_tex);
-        glUniform1i(tex, 0);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, atlas_width, atlas_height, 0, GL_RED, GL_UNSIGNED_BYTE, nullptr);
-        GL_ERRORS();
-
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // 1 byte alignment
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE); // clamping to avoid artifacts
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE); // clamping to avoid artifacts
-        GL_ERRORS();
-
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); // linear filtering usually best for text
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); // linear filtering usually best for text
-        GL_ERRORS();
-
-
-        // fill in the texture with all the glyphs
-        size_t x = 0;
-        for(auto &rc : render_chars) {
-            glTexSubImage2D(GL_TEXTURE_2D, 0, x, 0, rc.ch.Size.x, rc.ch.Size.y, GL_RED, GL_UNSIGNED_BYTE, rc.ch.data);
-            rc.tx = static_cast<float>(x) / atlas_width;
-            x += rc.ch.Size.x;
-        }
-        GL_ERRORS();
-
+        // get shader parameters
         auto projection = glm::ortho(0.0f, drawable_size.x, 0.0f, drawable_size.y);
-        glUniformMatrix4fv(glGetUniformLocation(Text::draw_text_program, "projection"), 1, GL_FALSE, &projection[0][0]);
-        glUniform3f(glGetUniformLocation(Text::draw_text_program, "textColor"), 1.f, 1.f, 1.f);
-        GL_ERRORS();
 
+        // assign some parameters
+        glUniformMatrix4fv(shader_proj, 1, GL_FALSE, &projection[0][0]);
+        glUniform3f(shader_color, color.x, color.y, color.z);
+        
         // use the texture containing the atlas
-        glBindTexture(GL_TEXTURE_2D, atlas_tex);
-        glUniform1i(tex, 0);
+        glBindTexture(GL_TEXTURE_2D, atlas->tex);
+        glUniform1i(shader_tex, 0);
         GL_ERRORS();
 
         // set up the VBO for vertex data
-        if (Text::VBO_deferred == 0) {
-            glGenBuffers(1, &Text::VBO_deferred);
-        }
-        glBindVertexArray(Text::VAO); // since glEnableVertexAttribArray sets state in the current VAO
-        glEnableVertexAttribArray(attribute_coord);
-        glBindBuffer(GL_ARRAY_BUFFER, Text::VBO_deferred);
-        glVertexAttribPointer(attribute_coord, 4, GL_FLOAT, GL_FALSE, 0, 0);
+        glBindVertexArray(VAO); // since glEnableVertexAttribArray sets state in the current VAO
+        glEnableVertexAttribArray(shader_coord);
+        glBindBuffer(GL_ARRAY_BUFFER, VBO);
+        glVertexAttribPointer(shader_coord, 4, GL_FLOAT, GL_FALSE, 0, 0);
         GL_ERRORS();
 
-        // loop through all characters
-        std::vector<float> render_data; // should be 6 * 4 * render_chars.size()
-        for (size_t i = 0; i < render_chars.size(); i++) {
-            const RenderCharacter &rc = render_chars[i];
-
-            float bw = rc.w;
-            float bh = rc.h;
-
-            if (!bw || !bh) // glyphs with no pixels
-                continue;
-
-            // each 4 tuple is a {x, y, s, t} to index into the vertex/texture coordinates/attribute
-            render_data.insert(render_data.end(), {
-                rc.xpos,        -rc.ypos - rc.h, rc.tx,                    bh / atlas_height,
-                rc.xpos,        -rc.ypos,        rc.tx,                    0.0f,
-                rc.xpos + rc.w, -rc.ypos,        rc.tx + bw / atlas_width, 0.0f,
-                rc.xpos,        -rc.ypos - rc.h, rc.tx,                    bh / atlas_height,
-                rc.xpos + rc.w, -rc.ypos,        rc.tx + bw / atlas_width, 0.0f,
-                rc.xpos + rc.w, -rc.ypos - rc.h, rc.tx + bw / atlas_width, bh / atlas_height
-            });
-        }
+        // draw triangles (this is the expensive part!)
         glBufferData(GL_ARRAY_BUFFER, sizeof(float) * render_data.size(), render_data.data(), GL_DYNAMIC_DRAW);
         glDrawArrays(GL_TRIANGLES, 0, render_data.size());
-        glDisableVertexAttribArray(attribute_coord);
+        glDisableVertexAttribArray(shader_coord);
         GL_ERRORS();
 
         // reset openGL stuff
         glBindVertexArray(0);
         glBindTexture(GL_TEXTURE_2D, 0);
-
-        // clean VBO
-        glBindBuffer(GL_ARRAY_BUFFER, 0);
-        // glDeleteBuffers(1, &VBO_deferred);
+        glUniform1i(shader_tex, 0); // disable the texture from this shader until next call
 
         glUseProgram(0);
-        glDeleteTextures(1, &atlas_tex);
 
         GL_ERRORS();
 
-        // it is very important to clear all the characters for the next frame else this will accumulate/leak!
-        render_chars.clear();
+        if (atlas != nullptr)
+            delete atlas;
     }
 };

--- a/Text.hpp
+++ b/Text.hpp
@@ -118,6 +118,9 @@ struct Text {
     struct Atlas {
         // attempting to "glom" all relevant textures to a single texture atlas
         // https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Text_Rendering_02
+
+        // especially helpful reading:
+        // https://gitlab.com/wikibooks-opengl/modern-tutorials/-/blob/master/text02_atlas/text.cpp#L226
         
         GLuint tex;
         unsigned int w, h;
@@ -402,6 +405,11 @@ struct Text {
         return anchor_x_start;
     }
 
+    void draw(float dt, const glm::vec2& drawable_size, float scale, const glm::vec2& pos, float ss_scale, glm::vec3 const &color) {
+        // overload to cast scale to int
+        draw(dt, drawable_size, static_cast<int>(scale), pos, ss_scale, color);
+    }
+
     void draw(float dt, const glm::vec2& drawable_size, int scale, const glm::vec2& pos, float ss_scale, glm::vec3 const &color) {
         // draw a text element using an atlas texture to draw it all at once
 
@@ -480,7 +488,7 @@ struct Text {
 
         // draw triangles (this is the expensive part!)
         glBufferData(GL_ARRAY_BUFFER, num_render_chars * sizeof(float) * 6 * 4, render_data.data(), GL_DYNAMIC_DRAW);
-        glDrawArrays(GL_TRIANGLES, 0, num_render_chars * 6);
+        glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(num_render_chars * 6));
         glDisableVertexAttribArray(shader_coord);
         GL_ERRORS();
 


### PR DESCRIPTION
Optimizing the performance of the text renderer which used to be really bad. Performance (degradation) used to scale with the number of characters on screen since the text render would talk to the GPU per character... this is wildly inefficient. 

Instead now we render all the relevant characters to a buffer (known as an [Atlas texture](https://en.wikibooks.org/wiki/OpenGL_Programming/Modern_OpenGL_Tutorial_Text_Rendering_02)) and sample from there to get our characters. This means our characters are less dynamic since we'll have to rebuild the atlas when resizing the font of our text, but since this is infrequent we still get big wins. 

Performance measurements: (in tutorial mode where there are lots of characters on screen)

Before:
- FPS ~20

After:
- FPS ~60 